### PR TITLE
feat: Configure block strength

### DIFF
--- a/src/client/kotlin/net/turtton/connectedtank/ConnectedTankDataGenerator.kt
+++ b/src/client/kotlin/net/turtton/connectedtank/ConnectedTankDataGenerator.kt
@@ -9,6 +9,7 @@ import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator
 import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput
 import net.fabricmc.fabric.api.datagen.v1.provider.FabricLanguageProvider
 import net.fabricmc.fabric.api.datagen.v1.provider.FabricRecipeProvider
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricTagProvider
 import net.minecraft.advancement.AdvancementRequirements
 import net.minecraft.advancement.AdvancementRewards
 import net.minecraft.advancement.criterion.RecipeUnlockedCriterion
@@ -34,6 +35,7 @@ import net.minecraft.recipe.book.RecipeCategory
 import net.minecraft.registry.RegistryKey
 import net.minecraft.registry.RegistryKeys
 import net.minecraft.registry.RegistryWrapper
+import net.minecraft.registry.tag.BlockTags
 import net.minecraft.registry.tag.ItemTags
 import net.minecraft.registry.tag.TagKey
 import net.minecraft.util.Identifier
@@ -48,6 +50,7 @@ object ConnectedTankDataGenerator : DataGeneratorEntrypoint {
         val pack = fabricDataGenerator.createPack()
         pack.addProvider(::ModelProvider)
         pack.addProvider(::RecipeProvider)
+        pack.addProvider(::BlockTagProvider)
         pack.addProvider(::EnglishLanguageProvider)
         pack.addProvider(::JapaneseLanguageProvider)
     }
@@ -326,6 +329,18 @@ object ConnectedTankDataGenerator : DataGeneratorEntrypoint {
                     "down" to borderStripElement(Triple(0, -0.01, 0), Triple(1, 0.01, 16), "down"),
                 ),
             )
+        }
+    }
+
+    private class BlockTagProvider(
+        output: FabricDataOutput,
+        registriesFuture: CompletableFuture<RegistryWrapper.WrapperLookup>,
+    ) : FabricTagProvider.BlockTagProvider(output, registriesFuture) {
+        override fun configure(wrapperLookup: RegistryWrapper.WrapperLookup) {
+            val pickaxeMineable = valueLookupBuilder(BlockTags.PICKAXE_MINEABLE)
+            for (block in CTBlocks.ALL_TANKS) {
+                pickaxeMineable.add(block)
+            }
         }
     }
 

--- a/src/main/generated/data/minecraft/tags/block/mineable/pickaxe.json
+++ b/src/main/generated/data/minecraft/tags/block/mineable/pickaxe.json
@@ -1,0 +1,11 @@
+{
+  "values": [
+    "connectedtank:connected_tank",
+    "connectedtank:stone_connected_tank",
+    "connectedtank:copper_connected_tank",
+    "connectedtank:iron_connected_tank",
+    "connectedtank:gold_connected_tank",
+    "connectedtank:diamond_connected_tank",
+    "connectedtank:netherite_connected_tank"
+  ]
+}

--- a/src/main/kotlin/net/turtton/connectedtank/block/CTBlocks.kt
+++ b/src/main/kotlin/net/turtton/connectedtank/block/CTBlocks.kt
@@ -38,7 +38,7 @@ object CTBlocks {
 
     private fun register(tier: TankTier): Block {
         val blockKey = RegistryKey.of(RegistryKeys.BLOCK, ModIdentifier(tier.id))
-        val settings = AbstractBlock.Settings.create().nonOpaque().registryKey(blockKey)
+        val settings = AbstractBlock.Settings.create().nonOpaque().strength(tier.hardness).registryKey(blockKey)
         val block = ConnectedTankBlock(tier, settings)
         return Registry.register(Registries.BLOCK, blockKey, block)
     }

--- a/src/main/kotlin/net/turtton/connectedtank/block/TankTier.kt
+++ b/src/main/kotlin/net/turtton/connectedtank/block/TankTier.kt
@@ -2,14 +2,14 @@ package net.turtton.connectedtank.block
 
 import net.turtton.connectedtank.config.CTServerConfig
 
-enum class TankTier(val id: String, val defaultMultiplier: Int) {
-    BASE("connected_tank", 1),
-    STONE("stone_connected_tank", 2),
-    COPPER("copper_connected_tank", 4),
-    IRON("iron_connected_tank", 8),
-    GOLD("gold_connected_tank", 16),
-    DIAMOND("diamond_connected_tank", 32),
-    NETHERITE("netherite_connected_tank", 64),
+enum class TankTier(val id: String, val defaultMultiplier: Int, val hardness: Float) {
+    BASE("connected_tank", 1, 0.3f),
+    STONE("stone_connected_tank", 2, 0.4f),
+    COPPER("copper_connected_tank", 4, 0.5f),
+    IRON("iron_connected_tank", 8, 0.6f),
+    GOLD("gold_connected_tank", 16, 0.7f),
+    DIAMOND("diamond_connected_tank", 32, 0.8f),
+    NETHERITE("netherite_connected_tank", 64, 0.9f),
     ;
 
     val bucketCapacity: Int

--- a/src/main/kotlin/net/turtton/connectedtank/item/CTItems.kt
+++ b/src/main/kotlin/net/turtton/connectedtank/item/CTItems.kt
@@ -20,7 +20,7 @@ object CTItems {
     val IRON_CONNECTED_TANK = registerTank(TankTier.IRON)
     val GOLD_CONNECTED_TANK = registerTank(TankTier.GOLD)
     val DIAMOND_CONNECTED_TANK = registerTank(TankTier.DIAMOND)
-    val NETHERITE_CONNECTED_TANK = registerTank(TankTier.NETHERITE)
+    val NETHERITE_CONNECTED_TANK = registerTank(TankTier.NETHERITE) { fireproof() }
 
     val ALL_TANK_ITEMS: List<BlockItem> = listOf(
         CONNECTED_TANK,
@@ -32,9 +32,15 @@ object CTItems {
         NETHERITE_CONNECTED_TANK,
     )
 
-    private fun registerTank(tier: TankTier): BlockItem {
+    private fun registerTank(
+        tier: TankTier,
+        additionalSettings: Item.Settings.() -> Unit = {},
+    ): BlockItem {
         val block = CTBlocks.ALL_TANKS.first { (it as? net.turtton.connectedtank.block.ConnectedTankBlock)?.tier == tier }
-        return register(tier.id, { BlockItem(block, it) }) { useBlockPrefixedTranslationKey() }
+        return register(tier.id, { BlockItem(block, it) }) {
+            useBlockPrefixedTranslationKey()
+            additionalSettings()
+        }
     }
 
     private fun <I : Item> register(


### PR DESCRIPTION
## Summary

- ティアごとに硬さ（hardness）を設定（BASE=0.3f〜NETHERITE=0.9f）
- ピッケルで採掘可能な `mineable/pickaxe` タグを追加
- ネザライトタンクアイテムに耐火属性を追加（溶岩・炎で消えない）

Closes #31