### PR TITLE
feat: Add fluid rendering for tank items in inventory

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+# shellcheck shell=bash
+if ! has nix_direnv_version || ! nix_direnv_version 3.1.1; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.1.1/direnvrc" "sha256-p+fzQdrms/hDa7g+soShAybJNo4bN4SIAeSfqNKgD5I="
+fi
+use flake

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import java.util.concurrent.TimeUnit
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -218,5 +219,100 @@ publishing {
         // Notice: This block does NOT have the same function as the block in the top level.
         // The repositories here will be used for publishing your artifact, not for
         // retrieving dependencies.
+    }
+}
+
+// Auto-start Xvfb for headless client test execution (Wayland / headless environments)
+// Shared state for Xvfb process between run task and cleanup task
+val xvfbState = objects.property<Process>()
+val xvfbShutdownHook = objects.property<Thread>()
+
+fun needsXvfb(): Boolean {
+    val display = System.getenv("DISPLAY")
+    if (display.isNullOrBlank()) return true
+    // For remote displays (e.g., SSH X11 forwarding like localhost:10.0), trust the env
+    if (display.contains(":") && !display.startsWith(":")) return false
+    // For local displays, check if the X11 socket file exists (simple heuristic; does not probe connection)
+    val displayNum = display.removePrefix(":").takeWhile { it.isDigit() }
+    val socket = File("/tmp/.X11-unix/X$displayNum")
+    return !socket.exists()
+}
+
+fun findXvfb(): String? {
+    val candidates = listOf("Xvfb", "/usr/bin/Xvfb")
+    return candidates.firstOrNull { name ->
+        runCatching {
+            ProcessBuilder("which", name)
+                .redirectErrorStream(true)
+                .start()
+                .waitFor() == 0
+        }.getOrDefault(false)
+    }
+}
+
+fun startXvfb(xvfb: String): Pair<Process, String> {
+    // Try multiple display numbers to handle concurrent usage
+    for (displayNum in 99..199) {
+        val display = ":$displayNum"
+        if (File("/tmp/.X11-unix/X$displayNum").exists()) continue
+
+        val process = ProcessBuilder(xvfb, display, "-screen", "0", "1280x1024x24", "-nolisten", "tcp")
+            .redirectErrorStream(true)
+            .start()
+
+        // Poll for X11 socket to appear (readiness check)
+        val socketFile = File("/tmp/.X11-unix/X$displayNum")
+        val deadline = System.currentTimeMillis() + 5_000
+        while (System.currentTimeMillis() < deadline) {
+            if (!process.isAlive) break
+            if (socketFile.exists()) return process to display
+            Thread.sleep(100)
+        }
+
+        // This display didn't work, clean up and try next
+        if (process.isAlive) process.destroyForcibly()
+    }
+    error("Failed to start Xvfb: no available display number in :99..:199")
+}
+
+val cleanupXvfbTask = tasks.register("cleanupXvfb") {
+    notCompatibleWithConfigurationCache("Manages Xvfb process lifecycle at execution time")
+    doLast {
+        xvfbState.orNull?.let { process ->
+            if (process.isAlive) {
+                logger.lifecycle("Stopping Xvfb (pid: ${process.pid()})")
+                process.destroy()
+                process.waitFor(5, TimeUnit.SECONDS)
+                if (process.isAlive) process.destroyForcibly()
+            }
+        }
+        // Remove shutdown hook after process cleanup (keeps hook as safety net until stop completes)
+        xvfbShutdownHook.orNull?.let { hook ->
+            runCatching { Runtime.getRuntime().removeShutdownHook(hook) }
+        }
+    }
+}
+
+tasks.named<JavaExec>("runClientGameTest") {
+    notCompatibleWithConfigurationCache("Manages Xvfb process lifecycle at execution time")
+    finalizedBy(cleanupXvfbTask)
+
+    doFirst {
+        if (!needsXvfb()) return@doFirst
+
+        val xvfb = findXvfb() ?: error(
+            "No usable DISPLAY found and Xvfb is not installed. " +
+                "Install Xvfb or run with a display server (e.g., xvfb-run ./gradlew runClientGameTest)",
+        )
+
+        val (process, display) = startXvfb(xvfb)
+        xvfbState.set(process)
+        // Last-resort cleanup for JVM crash (daemon shutdown)
+        val shutdownHook = Thread { if (process.isAlive) process.destroyForcibly() }
+        Runtime.getRuntime().addShutdownHook(shutdownHook)
+        xvfbShutdownHook.set(shutdownHook)
+
+        logger.lifecycle("Started Xvfb on display $display (pid: ${process.pid()})")
+        environment("DISPLAY", display)
     }
 }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,64 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": [
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1775126147,
+        "narHash": "sha256-J0dZU4atgcfo4QvM9D92uQ0Oe1eLTxBVXjJzdEMQpD0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8d8c1fa5b412c223ffa47410867813290cdedfef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,48 @@
+{
+  description = "A basic flake with a shell";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs.systems.url = "github:nix-systems/default";
+  inputs.flake-utils = {
+    url = "github:numtide/flake-utils";
+    inputs.systems.follows = "systems";
+  };
+
+  outputs =
+    { nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        libraries =
+          with pkgs;
+          lib.makeLibraryPath [
+            libpulseaudio
+            libGL
+            udev
+            flite
+            libx11
+            libxcursor
+            libxi
+            libxext
+            libxxf86vm
+            libxrandr
+          ];
+      in
+      {
+        formatter = pkgs.nixfmt-tree;
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            bashInteractive
+            xrandr
+            xorg-server # Provides Xvfb for headless client tests
+            pinact
+            zizmor
+          ];
+          shellHook = ''
+            export LD_LIBRARY_PATH=''${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}${libraries}
+          '';
+        };
+      }
+    );
+}
+

--- a/src/client/kotlin/net/turtton/connectedtank/ConnectedTankClient.kt
+++ b/src/client/kotlin/net/turtton/connectedtank/ConnectedTankClient.kt
@@ -12,6 +12,7 @@ import net.turtton.connectedtank.block.ConnectedTankBlockEntityRenderer
 import net.turtton.connectedtank.config.CTClientConfig
 import net.turtton.connectedtank.config.CTServerConfig
 import net.turtton.connectedtank.config.SyncedServerConfig
+import net.turtton.connectedtank.item.ConnectedTankItemRenderer
 import net.turtton.connectedtank.network.ConfigSyncPayload
 
 object ConnectedTankClient : ClientModInitializer {
@@ -20,6 +21,7 @@ object ConnectedTankClient : ClientModInitializer {
 
         CTBlocks.ALL_TANKS.forEach { BlockRenderLayerMap.putBlock(it, BlockRenderLayer.CUTOUT) }
         BlockEntityRendererFactories.register(CTBlockEntityTypes.CONNECTED_TANK, ::ConnectedTankBlockEntityRenderer)
+        ConnectedTankItemRenderer.register()
 
         ClientPlayNetworking.registerGlobalReceiver(ConfigSyncPayload.ID) { payload, _ ->
             SyncedServerConfig.syncedConfig = CTServerConfig(

--- a/src/client/kotlin/net/turtton/connectedtank/ConnectedTankDataGenerator.kt
+++ b/src/client/kotlin/net/turtton/connectedtank/ConnectedTankDataGenerator.kt
@@ -16,6 +16,7 @@ import net.minecraft.advancement.criterion.RecipeUnlockedCriterion
 import net.minecraft.block.Block
 import net.minecraft.client.data.BlockStateModelGenerator
 import net.minecraft.client.data.ItemModelGenerator
+import net.minecraft.client.data.ItemModels
 import net.minecraft.client.data.ModelSupplier
 import net.minecraft.client.data.MultipartBlockModelDefinitionCreator
 import net.minecraft.client.render.model.json.ModelVariant
@@ -43,6 +44,7 @@ import net.minecraft.util.collection.Pool
 import net.turtton.connectedtank.block.CTBlocks
 import net.turtton.connectedtank.block.ConnectedTankBlock
 import net.turtton.connectedtank.extension.ModIdentifier
+import net.turtton.connectedtank.item.ConnectedTankItemRenderer
 import net.turtton.connectedtank.recipe.TankUpgradeRecipe
 
 object ConnectedTankDataGenerator : DataGeneratorEntrypoint {
@@ -257,7 +259,13 @@ object ConnectedTankDataGenerator : DataGeneratorEntrypoint {
                 )
             }
             generator.modelCollector.accept(modelId, ModelSupplier { json })
-            generator.registerParentedItemModel(block, modelId)
+            generator.itemModelOutput.accept(
+                block.asItem(),
+                ItemModels.composite(
+                    ItemModels.basic(modelId),
+                    ItemModels.special(modelId, ConnectedTankItemRenderer.Unbaked()),
+                ),
+            )
         }
 
         // cullface を付けないこと。isSideInvisible() が Direction 単位で判定するため、

--- a/src/client/kotlin/net/turtton/connectedtank/block/ConnectedTankBlockEntityRenderer.kt
+++ b/src/client/kotlin/net/turtton/connectedtank/block/ConnectedTankBlockEntityRenderer.kt
@@ -1,35 +1,23 @@
 package net.turtton.connectedtank.block
 
 import kotlin.math.max
-import kotlin.math.sin
 import net.fabricmc.fabric.api.transfer.v1.client.fluid.FluidVariantRendering
-import net.minecraft.client.render.LightmapTextureManager
-import net.minecraft.client.render.OverlayTexture
-import net.minecraft.client.render.RenderLayer
-import net.minecraft.client.render.VertexConsumer
 import net.minecraft.client.render.VertexConsumerProvider
 import net.minecraft.client.render.block.entity.BlockEntityRenderer
 import net.minecraft.client.render.block.entity.BlockEntityRendererFactory
-import net.minecraft.client.texture.Sprite
 import net.minecraft.client.util.math.MatrixStack
 import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.Vec3d
 import net.turtton.connectedtank.config.CTClientConfig
 import net.turtton.connectedtank.config.CTClientConfig.RenderQuality
+import net.turtton.connectedtank.render.FluidRenderHelper
+import net.turtton.connectedtank.render.NeighborMask
+import net.turtton.connectedtank.render.WaveParams
 
 class ConnectedTankBlockEntityRenderer(
     @Suppress("UNUSED_PARAMETER") context: BlockEntityRendererFactory.Context,
 ) : BlockEntityRenderer<ConnectedTankBlockEntity> {
     companion object {
-        private const val INSET = 0.001f
-
-        private const val AMPLITUDE = 0.02f
-        private const val FREQUENCY = 1.2f
-        private const val SPEED = 0.25f
-        private const val SECONDARY_AMP = 0.01f
-        private const val SECONDARY_FREQ = 1.6f
-        private const val SECONDARY_SPEED = 0.18f
-
         private const val DECAY_TICKS = 60f
     }
 
@@ -47,9 +35,6 @@ class ConnectedTankBlockEntityRenderer(
         val sprite = FluidVariantRendering.getSprite(entity.fluidVariant) ?: return
         val color = FluidVariantRendering.getColor(entity.fluidVariant)
         val argb = (0xFF shl 24) or (color and 0x00FFFFFF)
-
-        val renderLayer = RenderLayer.getEntityTranslucent(sprite.atlasId)
-        val consumer = vertexConsumers.getBuffer(renderLayer)
 
         val world = entity.world
         val pos = entity.pos
@@ -74,16 +59,7 @@ class ConnectedTankBlockEntityRenderer(
         val hasWest = sameGroupNeighbor(pos.west())?.let { it.localFillLevel > 0f } == true
         val hasEast = sameGroupNeighbor(pos.east())?.let { it.localFillLevel > 0f } == true
 
-        val minX = if (hasWest) 0f else INSET
-        val maxX = if (hasEast) 1f else 1f - INSET
-        val minY = if (hasDown) 0f else INSET
-        val minZ = if (hasNorth) 0f else INSET
-        val maxZ = if (hasSouth) 1f else 1f - INSET
-
-        val fluidTop = minY + (1f - INSET - minY) * entity.localFillLevel
-
         matrices.push()
-        val entry = matrices.peek()
 
         val quality = CTClientConfig.instance.renderQuality
         val worldTime = world?.time?.toFloat() ?: 0f
@@ -96,221 +72,31 @@ class ConnectedTankBlockEntityRenderer(
         val worldX = pos.x.toFloat()
         val worldZ = pos.z.toFloat()
         val useWorldCoords = quality == RenderQuality.HIGH
-        renderAnimatedFluid(
-            consumer, entry, sprite, argb, fluidTop, animTime,
-            gridSize, useWorldCoords, worldX, worldZ, decayFactor,
-            minX, maxX, minY, minZ, maxZ,
-            hasUp, hasDown, hasNorth, hasSouth, hasWest, hasEast,
+
+        FluidRenderHelper.renderFluid(
+            vertexConsumers,
+            matrices,
+            sprite,
+            argb,
+            entity.localFillLevel,
+            WaveParams(
+                animTime = animTime,
+                gridSize = gridSize,
+                useWorldCoords = useWorldCoords,
+                worldX = worldX,
+                worldZ = worldZ,
+                decayFactor = decayFactor,
+            ),
+            NeighborMask(
+                up = hasUp,
+                down = hasDown,
+                north = hasNorth,
+                south = hasSouth,
+                west = hasWest,
+                east = hasEast,
+            ),
         )
 
         matrices.pop()
-    }
-
-    @Suppress("LongParameterList")
-    private fun renderAnimatedFluid(
-        consumer: VertexConsumer,
-        entry: MatrixStack.Entry,
-        sprite: Sprite,
-        argb: Int,
-        fluidTop: Float,
-        animTime: Float,
-        gridSize: Int,
-        useWorldCoords: Boolean,
-        worldX: Float,
-        worldZ: Float,
-        decayFactor: Float,
-        minX: Float,
-        maxX: Float,
-        minY: Float,
-        minZ: Float,
-        maxZ: Float,
-        hasUp: Boolean,
-        hasDown: Boolean,
-        hasNorth: Boolean,
-        hasSouth: Boolean,
-        hasWest: Boolean,
-        hasEast: Boolean,
-    ) {
-        val fullLight = LightmapTextureManager.MAX_LIGHT_COORDINATE
-        val ov = OverlayTexture.DEFAULT_UV
-        val u0 = sprite.minU
-        val u1 = sprite.maxU
-        val v0 = sprite.minV
-        val v1 = sprite.maxV
-        val maxY = 1f - INSET
-
-        val heightMap = Array(gridSize + 1) { FloatArray(gridSize + 1) }
-        val rangeX = maxX - minX
-        val rangeZ = maxZ - minZ
-        for (ix in 0..gridSize) {
-            for (iz in 0..gridSize) {
-                val localX = minX + rangeX * ix.toFloat() / gridSize
-                val localZ = minZ + rangeZ * iz.toFloat() / gridSize
-                val waveX = if (useWorldCoords) worldX + localX else localX
-                val waveZ = if (useWorldCoords) worldZ + localZ else localZ
-                val wave = decayFactor * (
-                    AMPLITUDE * sin(waveX * FREQUENCY + animTime * SPEED) +
-                        SECONDARY_AMP * sin(waveZ * SECONDARY_FREQ + animTime * SECONDARY_SPEED)
-                    )
-                heightMap[ix][iz] = (fluidTop + wave).coerceIn(minY, maxY)
-            }
-        }
-
-        // Top surface
-        if (!hasUp) {
-            for (ix in 0 until gridSize) {
-                for (iz in 0 until gridSize) {
-                    val x0 = minX + rangeX * ix.toFloat() / gridSize
-                    val x1g = minX + rangeX * (ix + 1).toFloat() / gridSize
-                    val z0 = minZ + rangeZ * iz.toFloat() / gridSize
-                    val z1g = minZ + rangeZ * (iz + 1).toFloat() / gridSize
-
-                    val su0 = u0 + (u1 - u0) * ix.toFloat() / gridSize
-                    val su1 = u0 + (u1 - u0) * (ix + 1).toFloat() / gridSize
-                    val sv0 = v0 + (v1 - v0) * iz.toFloat() / gridSize
-                    val sv1 = v0 + (v1 - v0) * (iz + 1).toFloat() / gridSize
-
-                    consumer.quadUV(
-                        entry, argb, ov, fullLight,
-                        x0, heightMap[ix][iz], z0, su0, sv0,
-                        x0, heightMap[ix][iz + 1], z1g, su0, sv1,
-                        x1g, heightMap[ix + 1][iz + 1], z1g, su1, sv1,
-                        x1g, heightMap[ix + 1][iz], z0, su1, sv0,
-                        0f, 1f, 0f,
-                    )
-                }
-            }
-        }
-
-        // Bottom surface (flat, no wave)
-        if (!hasDown) {
-            consumer.quadUV(
-                entry, argb, ov, fullLight,
-                minX, minY, maxZ, u0, v0,
-                minX, minY, minZ, u0, v1,
-                maxX, minY, minZ, u1, v1,
-                maxX, minY, maxZ, u1, v0,
-                0f, -1f, 0f,
-            )
-        }
-
-        // North side (z = minZ)
-        if (!hasNorth) {
-            for (ix in 0 until gridSize) {
-                val x0 = minX + rangeX * ix.toFloat() / gridSize
-                val x1g = minX + rangeX * (ix + 1).toFloat() / gridSize
-                val topY0 = heightMap[ix][0]
-                val topY1 = heightMap[ix + 1][0]
-                val su0 = u0 + (u1 - u0) * ix.toFloat() / gridSize
-                val su1 = u0 + (u1 - u0) * (ix + 1).toFloat() / gridSize
-
-                consumer.quadUV(
-                    entry, argb, ov, fullLight,
-                    x0, topY0, minZ, su0, v0,
-                    x1g, topY1, minZ, su1, v0,
-                    x1g, minY, minZ, su1, v1,
-                    x0, minY, minZ, su0, v1,
-                    0f, 0f, -1f,
-                )
-            }
-        }
-
-        // South side (z = maxZ)
-        if (!hasSouth) {
-            for (ix in 0 until gridSize) {
-                val x0 = minX + rangeX * ix.toFloat() / gridSize
-                val x1g = minX + rangeX * (ix + 1).toFloat() / gridSize
-                val topY0 = heightMap[ix][gridSize]
-                val topY1 = heightMap[ix + 1][gridSize]
-                val su0 = u0 + (u1 - u0) * ix.toFloat() / gridSize
-                val su1 = u0 + (u1 - u0) * (ix + 1).toFloat() / gridSize
-
-                consumer.quadUV(
-                    entry, argb, ov, fullLight,
-                    x1g, topY1, maxZ, su1, v0,
-                    x0, topY0, maxZ, su0, v0,
-                    x0, minY, maxZ, su0, v1,
-                    x1g, minY, maxZ, su1, v1,
-                    0f, 0f, 1f,
-                )
-            }
-        }
-
-        // West side (x = minX)
-        if (!hasWest) {
-            for (iz in 0 until gridSize) {
-                val z0 = minZ + rangeZ * iz.toFloat() / gridSize
-                val z1g = minZ + rangeZ * (iz + 1).toFloat() / gridSize
-                val topY0 = heightMap[0][iz]
-                val topY1 = heightMap[0][iz + 1]
-                val su0 = u0 + (u1 - u0) * iz.toFloat() / gridSize
-                val su1 = u0 + (u1 - u0) * (iz + 1).toFloat() / gridSize
-
-                consumer.quadUV(
-                    entry, argb, ov, fullLight,
-                    minX, topY0, z1g, su1, v0,
-                    minX, topY1, z0, su0, v0,
-                    minX, minY, z0, su0, v1,
-                    minX, minY, z1g, su1, v1,
-                    -1f, 0f, 0f,
-                )
-            }
-        }
-
-        // East side (x = maxX)
-        if (!hasEast) {
-            for (iz in 0 until gridSize) {
-                val z0 = minZ + rangeZ * iz.toFloat() / gridSize
-                val z1g = minZ + rangeZ * (iz + 1).toFloat() / gridSize
-                val topY0 = heightMap[gridSize][iz]
-                val topY1 = heightMap[gridSize][iz + 1]
-                val su0 = u0 + (u1 - u0) * iz.toFloat() / gridSize
-                val su1 = u0 + (u1 - u0) * (iz + 1).toFloat() / gridSize
-
-                consumer.quadUV(
-                    entry, argb, ov, fullLight,
-                    maxX, topY0, z0, su0, v0,
-                    maxX, topY1, z1g, su1, v0,
-                    maxX, minY, z1g, su1, v1,
-                    maxX, minY, z0, su0, v1,
-                    1f, 0f, 0f,
-                )
-            }
-        }
-    }
-
-    private fun VertexConsumer.quadUV(
-        entry: MatrixStack.Entry,
-        argb: Int,
-        ov: Int,
-        fullLight: Int,
-        x1: Float,
-        y1: Float,
-        z1: Float,
-        su0: Float,
-        sv0: Float,
-        x2: Float,
-        y2: Float,
-        z2: Float,
-        su1: Float,
-        sv1: Float,
-        x3: Float,
-        y3: Float,
-        z3: Float,
-        su2: Float,
-        sv2: Float,
-        x4: Float,
-        y4: Float,
-        z4: Float,
-        su3: Float,
-        sv3: Float,
-        nx: Float,
-        ny: Float,
-        nz: Float,
-    ) {
-        vertex(entry, x1, y1, z1).color(argb).texture(su0, sv0).overlay(ov).light(fullLight).normal(entry, nx, ny, nz)
-        vertex(entry, x2, y2, z2).color(argb).texture(su1, sv1).overlay(ov).light(fullLight).normal(entry, nx, ny, nz)
-        vertex(entry, x3, y3, z3).color(argb).texture(su2, sv2).overlay(ov).light(fullLight).normal(entry, nx, ny, nz)
-        vertex(entry, x4, y4, z4).color(argb).texture(su3, sv3).overlay(ov).light(fullLight).normal(entry, nx, ny, nz)
     }
 }

--- a/src/client/kotlin/net/turtton/connectedtank/item/ConnectedTankItemRenderer.kt
+++ b/src/client/kotlin/net/turtton/connectedtank/item/ConnectedTankItemRenderer.kt
@@ -1,0 +1,91 @@
+package net.turtton.connectedtank.item
+
+import com.mojang.serialization.MapCodec
+import net.fabricmc.fabric.api.transfer.v1.client.fluid.FluidVariantRendering
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidConstants
+import net.minecraft.client.render.RenderLayer
+import net.minecraft.client.render.VertexConsumerProvider
+import net.minecraft.client.render.entity.model.LoadedEntityModels
+import net.minecraft.client.render.item.model.special.SpecialModelRenderer
+import net.minecraft.client.render.item.model.special.SpecialModelTypes
+import net.minecraft.client.util.math.MatrixStack
+import net.minecraft.item.BlockItem
+import net.minecraft.item.ItemDisplayContext
+import net.minecraft.item.ItemStack
+import net.minecraft.util.Identifier
+import net.turtton.connectedtank.block.ConnectedTankBlock
+import net.turtton.connectedtank.component.CTDataComponentTypes
+import net.turtton.connectedtank.config.CTClientConfig
+import net.turtton.connectedtank.config.CTClientConfig.RenderQuality
+import net.turtton.connectedtank.config.CTServerConfig
+import net.turtton.connectedtank.config.SyncedServerConfig
+import net.turtton.connectedtank.render.FluidRenderHelper
+import net.turtton.connectedtank.render.WaveParams
+import org.joml.Vector3f
+
+class ConnectedTankItemRenderer : SpecialModelRenderer<ItemStack> {
+    override fun getData(stack: ItemStack): ItemStack? = stack
+
+    override fun render(
+        data: ItemStack?,
+        displayContext: ItemDisplayContext,
+        matrices: MatrixStack,
+        vertexConsumers: VertexConsumerProvider,
+        light: Int,
+        overlay: Int,
+        glint: Boolean,
+    ) {
+        data ?: return
+        val fluidData = data.get(CTDataComponentTypes.TANK_FLUID) ?: return
+        if (fluidData.variant.isBlank || fluidData.amount <= 0L) return
+
+        val sprite = FluidVariantRendering.getSprite(fluidData.variant) ?: return
+        val color = FluidVariantRendering.getColor(fluidData.variant)
+        val argb = (0xFF shl 24) or (color and 0x00FFFFFF)
+
+        val tankBlock = (data.item as? BlockItem)?.block as? ConnectedTankBlock ?: return
+        val serverConfig = SyncedServerConfig.syncedConfig ?: CTServerConfig.instance
+        val capacity = serverConfig.getTierCapacity(tankBlock.tier) * FluidConstants.BUCKET
+        if (capacity <= 0L) return
+        val fillLevel = (fluidData.amount.toFloat() / capacity.toFloat()).coerceIn(0f, 1f)
+
+        val quality = CTClientConfig.instance.renderQuality
+        val gridSize = if (quality == RenderQuality.HIGH) 8 else 4
+
+        matrices.push()
+        try {
+            FluidRenderHelper.renderFluid(
+                vertexConsumers,
+                matrices,
+                sprite,
+                argb,
+                fillLevel,
+                WaveParams(animTime = 0f, gridSize = gridSize),
+                renderLayer = RenderLayer.getItemEntityTranslucentCull(sprite.atlasId),
+            )
+        } finally {
+            matrices.pop()
+        }
+    }
+
+    override fun collectVertices(vertices: MutableSet<Vector3f>) {
+    }
+
+    class Unbaked : SpecialModelRenderer.Unbaked {
+        override fun bake(entityModels: LoadedEntityModels): SpecialModelRenderer<*> = ConnectedTankItemRenderer()
+
+        override fun getCodec(): MapCodec<out SpecialModelRenderer.Unbaked> = CODEC
+
+        companion object {
+            val CODEC: MapCodec<Unbaked> = MapCodec.unit(Unbaked())
+        }
+    }
+
+    companion object {
+        val ID: Identifier = Identifier.of("connectedtank", "tank_fluid")
+
+        fun register() {
+            SpecialModelTypes.ID_MAPPER.put(ID, Unbaked.CODEC)
+        }
+    }
+}

--- a/src/client/kotlin/net/turtton/connectedtank/render/FluidRenderHelper.kt
+++ b/src/client/kotlin/net/turtton/connectedtank/render/FluidRenderHelper.kt
@@ -1,0 +1,409 @@
+package net.turtton.connectedtank.render
+
+import kotlin.math.sin
+import net.minecraft.client.render.LightmapTextureManager
+import net.minecraft.client.render.OverlayTexture
+import net.minecraft.client.render.RenderLayer
+import net.minecraft.client.render.VertexConsumer
+import net.minecraft.client.render.VertexConsumerProvider
+import net.minecraft.client.texture.Sprite
+import net.minecraft.client.util.math.MatrixStack
+
+data class WaveParams(
+    val animTime: Float,
+    val gridSize: Int,
+    val useWorldCoords: Boolean = false,
+    val worldX: Float = 0f,
+    val worldZ: Float = 0f,
+    val decayFactor: Float = 0f,
+)
+
+data class NeighborMask(
+    val up: Boolean = false,
+    val down: Boolean = false,
+    val north: Boolean = false,
+    val south: Boolean = false,
+    val west: Boolean = false,
+    val east: Boolean = false,
+)
+
+object FluidRenderHelper {
+    private const val INSET = 0.001f
+
+    private const val AMPLITUDE = 0.02f
+    private const val FREQUENCY = 1.2f
+    private const val SPEED = 0.25f
+    private const val SECONDARY_AMP = 0.01f
+    private const val SECONDARY_FREQ = 1.6f
+    private const val SECONDARY_SPEED = 0.18f
+
+    fun renderFluid(
+        vertexConsumers: VertexConsumerProvider,
+        matrices: MatrixStack,
+        sprite: Sprite,
+        argb: Int,
+        fillLevel: Float,
+        wave: WaveParams,
+        neighbors: NeighborMask = NeighborMask(),
+        renderLayer: RenderLayer = RenderLayer.getEntityTranslucent(sprite.atlasId),
+    ) {
+        if (fillLevel <= 0f || wave.gridSize <= 0) return
+
+        val minX = if (neighbors.west) 0f else INSET
+        val maxX = if (neighbors.east) 1f else 1f - INSET
+        val minY = if (neighbors.down) 0f else INSET
+        val minZ = if (neighbors.north) 0f else INSET
+        val maxZ = if (neighbors.south) 1f else 1f - INSET
+
+        val fluidTop = minY + (1f - INSET - minY) * fillLevel
+
+        val consumer = vertexConsumers.getBuffer(renderLayer)
+        val entry = matrices.peek()
+
+        renderAnimatedFluid(
+            consumer,
+            entry,
+            sprite,
+            argb,
+            fluidTop,
+            wave,
+            minX,
+            maxX,
+            minY,
+            minZ,
+            maxZ,
+            neighbors,
+        )
+    }
+
+    @Suppress("LongParameterList")
+    private fun renderAnimatedFluid(
+        consumer: VertexConsumer,
+        entry: MatrixStack.Entry,
+        sprite: Sprite,
+        argb: Int,
+        fluidTop: Float,
+        wave: WaveParams,
+        minX: Float,
+        maxX: Float,
+        minY: Float,
+        minZ: Float,
+        maxZ: Float,
+        neighbors: NeighborMask,
+    ) {
+        val fullLight = LightmapTextureManager.MAX_LIGHT_COORDINATE
+        val ov = OverlayTexture.DEFAULT_UV
+        val u0 = sprite.minU
+        val u1 = sprite.maxU
+        val v0 = sprite.minV
+        val v1 = sprite.maxV
+        val maxY = 1f - INSET
+
+        val gridSize = wave.gridSize
+        val heightMap = Array(gridSize + 1) { FloatArray(gridSize + 1) }
+        val rangeX = maxX - minX
+        val rangeZ = maxZ - minZ
+        for (ix in 0..gridSize) {
+            for (iz in 0..gridSize) {
+                val localX = minX + rangeX * ix.toFloat() / gridSize
+                val localZ = minZ + rangeZ * iz.toFloat() / gridSize
+                val waveX = if (wave.useWorldCoords) wave.worldX + localX else localX
+                val waveZ = if (wave.useWorldCoords) wave.worldZ + localZ else localZ
+                val w =
+                    wave.decayFactor * (
+                        AMPLITUDE * sin(waveX * FREQUENCY + wave.animTime * SPEED) +
+                            SECONDARY_AMP * sin(waveZ * SECONDARY_FREQ + wave.animTime * SECONDARY_SPEED)
+                        )
+                heightMap[ix][iz] = (fluidTop + w).coerceIn(minY, maxY)
+            }
+        }
+
+        // Top surface
+        if (!neighbors.up) {
+            for (ix in 0 until gridSize) {
+                for (iz in 0 until gridSize) {
+                    val x0 = minX + rangeX * ix.toFloat() / gridSize
+                    val x1g = minX + rangeX * (ix + 1).toFloat() / gridSize
+                    val z0 = minZ + rangeZ * iz.toFloat() / gridSize
+                    val z1g = minZ + rangeZ * (iz + 1).toFloat() / gridSize
+
+                    val su0 = u0 + (u1 - u0) * ix.toFloat() / gridSize
+                    val su1 = u0 + (u1 - u0) * (ix + 1).toFloat() / gridSize
+                    val sv0 = v0 + (v1 - v0) * iz.toFloat() / gridSize
+                    val sv1 = v0 + (v1 - v0) * (iz + 1).toFloat() / gridSize
+
+                    consumer.quadUV(
+                        entry,
+                        argb,
+                        ov,
+                        fullLight,
+                        x0,
+                        heightMap[ix][iz],
+                        z0,
+                        su0,
+                        sv0,
+                        x0,
+                        heightMap[ix][iz + 1],
+                        z1g,
+                        su0,
+                        sv1,
+                        x1g,
+                        heightMap[ix + 1][iz + 1],
+                        z1g,
+                        su1,
+                        sv1,
+                        x1g,
+                        heightMap[ix + 1][iz],
+                        z0,
+                        su1,
+                        sv0,
+                        0f,
+                        1f,
+                        0f,
+                    )
+                }
+            }
+        }
+
+        // Bottom surface (flat, no wave)
+        if (!neighbors.down) {
+            consumer.quadUV(
+                entry,
+                argb,
+                ov,
+                fullLight,
+                minX,
+                minY,
+                maxZ,
+                u0,
+                v0,
+                minX,
+                minY,
+                minZ,
+                u0,
+                v1,
+                maxX,
+                minY,
+                minZ,
+                u1,
+                v1,
+                maxX,
+                minY,
+                maxZ,
+                u1,
+                v0,
+                0f,
+                -1f,
+                0f,
+            )
+        }
+
+        // North side (z = minZ)
+        if (!neighbors.north) {
+            for (ix in 0 until gridSize) {
+                val x0 = minX + rangeX * ix.toFloat() / gridSize
+                val x1g = minX + rangeX * (ix + 1).toFloat() / gridSize
+                val topY0 = heightMap[ix][0]
+                val topY1 = heightMap[ix + 1][0]
+                val su0 = u0 + (u1 - u0) * ix.toFloat() / gridSize
+                val su1 = u0 + (u1 - u0) * (ix + 1).toFloat() / gridSize
+
+                consumer.quadUV(
+                    entry,
+                    argb,
+                    ov,
+                    fullLight,
+                    x0,
+                    topY0,
+                    minZ,
+                    su0,
+                    v0,
+                    x1g,
+                    topY1,
+                    minZ,
+                    su1,
+                    v0,
+                    x1g,
+                    minY,
+                    minZ,
+                    su1,
+                    v1,
+                    x0,
+                    minY,
+                    minZ,
+                    su0,
+                    v1,
+                    0f,
+                    0f,
+                    -1f,
+                )
+            }
+        }
+
+        // South side (z = maxZ)
+        if (!neighbors.south) {
+            for (ix in 0 until gridSize) {
+                val x0 = minX + rangeX * ix.toFloat() / gridSize
+                val x1g = minX + rangeX * (ix + 1).toFloat() / gridSize
+                val topY0 = heightMap[ix][gridSize]
+                val topY1 = heightMap[ix + 1][gridSize]
+                val su0 = u0 + (u1 - u0) * ix.toFloat() / gridSize
+                val su1 = u0 + (u1 - u0) * (ix + 1).toFloat() / gridSize
+
+                consumer.quadUV(
+                    entry,
+                    argb,
+                    ov,
+                    fullLight,
+                    x1g,
+                    topY1,
+                    maxZ,
+                    su1,
+                    v0,
+                    x0,
+                    topY0,
+                    maxZ,
+                    su0,
+                    v0,
+                    x0,
+                    minY,
+                    maxZ,
+                    su0,
+                    v1,
+                    x1g,
+                    minY,
+                    maxZ,
+                    su1,
+                    v1,
+                    0f,
+                    0f,
+                    1f,
+                )
+            }
+        }
+
+        // West side (x = minX)
+        if (!neighbors.west) {
+            for (iz in 0 until gridSize) {
+                val z0 = minZ + rangeZ * iz.toFloat() / gridSize
+                val z1g = minZ + rangeZ * (iz + 1).toFloat() / gridSize
+                val topY0 = heightMap[0][iz]
+                val topY1 = heightMap[0][iz + 1]
+                val su0 = u0 + (u1 - u0) * iz.toFloat() / gridSize
+                val su1 = u0 + (u1 - u0) * (iz + 1).toFloat() / gridSize
+
+                consumer.quadUV(
+                    entry,
+                    argb,
+                    ov,
+                    fullLight,
+                    minX,
+                    topY0,
+                    z1g,
+                    su1,
+                    v0,
+                    minX,
+                    topY1,
+                    z0,
+                    su0,
+                    v0,
+                    minX,
+                    minY,
+                    z0,
+                    su0,
+                    v1,
+                    minX,
+                    minY,
+                    z1g,
+                    su1,
+                    v1,
+                    -1f,
+                    0f,
+                    0f,
+                )
+            }
+        }
+
+        // East side (x = maxX)
+        if (!neighbors.east) {
+            for (iz in 0 until gridSize) {
+                val z0 = minZ + rangeZ * iz.toFloat() / gridSize
+                val z1g = minZ + rangeZ * (iz + 1).toFloat() / gridSize
+                val topY0 = heightMap[gridSize][iz]
+                val topY1 = heightMap[gridSize][iz + 1]
+                val su0 = u0 + (u1 - u0) * iz.toFloat() / gridSize
+                val su1 = u0 + (u1 - u0) * (iz + 1).toFloat() / gridSize
+
+                consumer.quadUV(
+                    entry,
+                    argb,
+                    ov,
+                    fullLight,
+                    maxX,
+                    topY0,
+                    z0,
+                    su0,
+                    v0,
+                    maxX,
+                    topY1,
+                    z1g,
+                    su1,
+                    v0,
+                    maxX,
+                    minY,
+                    z1g,
+                    su1,
+                    v1,
+                    maxX,
+                    minY,
+                    z0,
+                    su0,
+                    v1,
+                    1f,
+                    0f,
+                    0f,
+                )
+            }
+        }
+    }
+
+    @Suppress("LongParameterList")
+    private fun VertexConsumer.quadUV(
+        entry: MatrixStack.Entry,
+        argb: Int,
+        ov: Int,
+        fullLight: Int,
+        x1: Float,
+        y1: Float,
+        z1: Float,
+        su0: Float,
+        sv0: Float,
+        x2: Float,
+        y2: Float,
+        z2: Float,
+        su1: Float,
+        sv1: Float,
+        x3: Float,
+        y3: Float,
+        z3: Float,
+        su2: Float,
+        sv2: Float,
+        x4: Float,
+        y4: Float,
+        z4: Float,
+        su3: Float,
+        sv3: Float,
+        nx: Float,
+        ny: Float,
+        nz: Float,
+    ) {
+        vertex(entry, x1, y1, z1).color(argb).texture(su0, sv0).overlay(ov).light(fullLight)
+            .normal(entry, nx, ny, nz)
+        vertex(entry, x2, y2, z2).color(argb).texture(su1, sv1).overlay(ov).light(fullLight)
+            .normal(entry, nx, ny, nz)
+        vertex(entry, x3, y3, z3).color(argb).texture(su2, sv2).overlay(ov).light(fullLight)
+            .normal(entry, nx, ny, nz)
+        vertex(entry, x4, y4, z4).color(argb).texture(su3, sv3).overlay(ov).light(fullLight)
+            .normal(entry, nx, ny, nz)
+    }
+}

--- a/src/clientGametest/kotlin/net/turtton/connectedtank/test/ConnectedTankClientGameTest.kt
+++ b/src/clientGametest/kotlin/net/turtton/connectedtank/test/ConnectedTankClientGameTest.kt
@@ -6,12 +6,16 @@ import net.fabricmc.fabric.api.client.gametest.v1.context.TestServerContext
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidConstants
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant
 import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction
+import net.minecraft.client.gui.screen.ingame.InventoryScreen
 import net.minecraft.fluid.Fluids
+import net.minecraft.item.ItemStack
 import net.minecraft.server.MinecraftServer
 import net.minecraft.util.math.BlockPos
 import net.minecraft.world.World
 import net.turtton.connectedtank.block.CTBlocks
 import net.turtton.connectedtank.block.TankFluidStorage
+import net.turtton.connectedtank.block.TankTier
+import net.turtton.connectedtank.component.CTDataComponentTypes
 import net.turtton.connectedtank.config.CTClientConfig
 import net.turtton.connectedtank.config.CTServerConfig
 import net.turtton.connectedtank.world.FluidStoragePersistentState
@@ -46,6 +50,7 @@ object ConnectedTankClientGameTest : FabricClientGameTest {
             testVerticalPartialFillTopFace(context, server)
             testVerticalDifferentFluidsStacked(context, server)
             testVerticalSameFluidDifferentGroups(context, server)
+            testItemInventory(context, server)
         }
     }
 
@@ -258,5 +263,54 @@ object ConnectedTankClientGameTest : FabricClientGameTest {
         // Jade のサーバーデータ取得・描画のために長めに待機
         context.waitTicks(40)
         context.takeScreenshot("6_jade_fluid_tooltip")
+    }
+
+    private fun testItemInventory(context: ClientGameTestContext, server: TestServerContext) {
+        server.runCommand("gamemode survival @p")
+        context.waitTicks(5)
+
+        server.onServer { srv ->
+            val player = srv.playerManager.playerList.firstOrNull() ?: return@onServer
+            val inventory = player.inventory
+            inventory.clear()
+
+            var slot = 0
+            val water = FluidVariant.of(Fluids.WATER)
+            for (tier in TankTier.entries) {
+                val block = CTBlocks.ALL_TANKS.firstOrNull {
+                    (it as? net.turtton.connectedtank.block.ConnectedTankBlock)?.tier == tier
+                } ?: continue
+                val item = block.asItem()
+                val tierCapacity = CTServerConfig.instance.getTierCapacity(tier)
+
+                val halfStack = ItemStack(item).also { stack ->
+                    stack.set(
+                        CTDataComponentTypes.TANK_FLUID,
+                        TankFluidStorage.ExistingData(water, FluidConstants.BUCKET * tierCapacity / 2),
+                    )
+                }
+                if (slot < 36) inventory.setStack(slot++, halfStack)
+
+                val fullStack = ItemStack(item).also { stack ->
+                    stack.set(
+                        CTDataComponentTypes.TANK_FLUID,
+                        TankFluidStorage.ExistingData(water, FluidConstants.BUCKET * tierCapacity),
+                    )
+                }
+                if (slot < 36) inventory.setStack(slot++, fullStack)
+            }
+        }
+        context.waitTicks(5)
+
+        context.input.pressKey(GLFW.GLFW_KEY_E)
+        context.waitForScreen(InventoryScreen::class.java)
+        context.waitTicks(10)
+        context.takeScreenshot("10_item_inventory_all_tiers")
+
+        context.input.pressKey(GLFW.GLFW_KEY_ESCAPE)
+        context.waitTicks(3)
+
+        server.runCommand("gamemode spectator @p")
+        context.waitTicks(5)
     }
 }

--- a/src/main/generated/assets/connectedtank/items/connected_tank.json
+++ b/src/main/generated/assets/connectedtank/items/connected_tank.json
@@ -1,6 +1,18 @@
 {
   "model": {
-    "type": "minecraft:model",
-    "model": "connectedtank:block/connected_tank_item"
+    "type": "minecraft:composite",
+    "models": [
+      {
+        "type": "minecraft:model",
+        "model": "connectedtank:block/connected_tank_item"
+      },
+      {
+        "type": "minecraft:special",
+        "base": "connectedtank:block/connected_tank_item",
+        "model": {
+          "type": "connectedtank:tank_fluid"
+        }
+      }
+    ]
   }
 }

--- a/src/main/generated/assets/connectedtank/items/copper_connected_tank.json
+++ b/src/main/generated/assets/connectedtank/items/copper_connected_tank.json
@@ -1,6 +1,18 @@
 {
   "model": {
-    "type": "minecraft:model",
-    "model": "connectedtank:block/copper_connected_tank_item"
+    "type": "minecraft:composite",
+    "models": [
+      {
+        "type": "minecraft:model",
+        "model": "connectedtank:block/copper_connected_tank_item"
+      },
+      {
+        "type": "minecraft:special",
+        "base": "connectedtank:block/copper_connected_tank_item",
+        "model": {
+          "type": "connectedtank:tank_fluid"
+        }
+      }
+    ]
   }
 }

--- a/src/main/generated/assets/connectedtank/items/diamond_connected_tank.json
+++ b/src/main/generated/assets/connectedtank/items/diamond_connected_tank.json
@@ -1,6 +1,18 @@
 {
   "model": {
-    "type": "minecraft:model",
-    "model": "connectedtank:block/diamond_connected_tank_item"
+    "type": "minecraft:composite",
+    "models": [
+      {
+        "type": "minecraft:model",
+        "model": "connectedtank:block/diamond_connected_tank_item"
+      },
+      {
+        "type": "minecraft:special",
+        "base": "connectedtank:block/diamond_connected_tank_item",
+        "model": {
+          "type": "connectedtank:tank_fluid"
+        }
+      }
+    ]
   }
 }

--- a/src/main/generated/assets/connectedtank/items/gold_connected_tank.json
+++ b/src/main/generated/assets/connectedtank/items/gold_connected_tank.json
@@ -1,6 +1,18 @@
 {
   "model": {
-    "type": "minecraft:model",
-    "model": "connectedtank:block/gold_connected_tank_item"
+    "type": "minecraft:composite",
+    "models": [
+      {
+        "type": "minecraft:model",
+        "model": "connectedtank:block/gold_connected_tank_item"
+      },
+      {
+        "type": "minecraft:special",
+        "base": "connectedtank:block/gold_connected_tank_item",
+        "model": {
+          "type": "connectedtank:tank_fluid"
+        }
+      }
+    ]
   }
 }

--- a/src/main/generated/assets/connectedtank/items/iron_connected_tank.json
+++ b/src/main/generated/assets/connectedtank/items/iron_connected_tank.json
@@ -1,6 +1,18 @@
 {
   "model": {
-    "type": "minecraft:model",
-    "model": "connectedtank:block/iron_connected_tank_item"
+    "type": "minecraft:composite",
+    "models": [
+      {
+        "type": "minecraft:model",
+        "model": "connectedtank:block/iron_connected_tank_item"
+      },
+      {
+        "type": "minecraft:special",
+        "base": "connectedtank:block/iron_connected_tank_item",
+        "model": {
+          "type": "connectedtank:tank_fluid"
+        }
+      }
+    ]
   }
 }

--- a/src/main/generated/assets/connectedtank/items/netherite_connected_tank.json
+++ b/src/main/generated/assets/connectedtank/items/netherite_connected_tank.json
@@ -1,6 +1,18 @@
 {
   "model": {
-    "type": "minecraft:model",
-    "model": "connectedtank:block/netherite_connected_tank_item"
+    "type": "minecraft:composite",
+    "models": [
+      {
+        "type": "minecraft:model",
+        "model": "connectedtank:block/netherite_connected_tank_item"
+      },
+      {
+        "type": "minecraft:special",
+        "base": "connectedtank:block/netherite_connected_tank_item",
+        "model": {
+          "type": "connectedtank:tank_fluid"
+        }
+      }
+    ]
   }
 }

--- a/src/main/generated/assets/connectedtank/items/stone_connected_tank.json
+++ b/src/main/generated/assets/connectedtank/items/stone_connected_tank.json
@@ -1,6 +1,18 @@
 {
   "model": {
-    "type": "minecraft:model",
-    "model": "connectedtank:block/stone_connected_tank_item"
+    "type": "minecraft:composite",
+    "models": [
+      {
+        "type": "minecraft:model",
+        "model": "connectedtank:block/stone_connected_tank_item"
+      },
+      {
+        "type": "minecraft:special",
+        "base": "connectedtank:block/stone_connected_tank_item",
+        "model": {
+          "type": "connectedtank:tank_fluid"
+        }
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- タンクアイテムのインベントリ表示に液体レンダリングを追加
- `SpecialModelRenderer` を使用して、タンクアイテム内の液体をアニメーション付き波面で描画
- ヘッドレス環境 (Wayland / CI) でのクライアントゲームテスト実行のため、Xvfb 自動起動を追加

## Changes

### Fluid Rendering (`ConnectedTankItemRenderer` + `FluidRenderHelper`)
- `ConnectedTankItemRenderer`: タンクアイテムの `SpecialModelRenderer` 実装。`TANK_FLUID` データコンポーネントから液体データを読み取り、充填レベルに応じた描画を行う
- `FluidRenderHelper`: ブロック/アイテム共通の液体メッシュ描画。グリッドベースの波面生成、全面のバーテックス描画、品質設定 (LOW/MEDIUM/HIGH) に対応
- `ConnectedTankBlockEntityRenderer` のリファクタリング: 液体描画ロジックを `FluidRenderHelper` に抽出

### Client Game Tests
- `testItemInventory`: 全ティア (木〜ネザライト) の半分/満タンの水タンクアイテムをインベントリに配置し、スクリーンショットで視覚検証

### Xvfb Auto-start (`build.gradle.kts`)
- `needsXvfb()` / `findXvfb()` / `startXvfb()`: DISPLAY 環境変数とX11ソケットを確認し、必要時に Xvfb を自動起動
- `cleanupXvfb` タスク: テスト後のプロセス停止とシャットダウンフック除去
- Nix devShell (`flake.nix`): GL/X11 ライブラリと Xvfb を含む開発環境

## Verified
- `./gradlew build` ✅ (30 server game tests passed)
- `./gradlew runClientGameTest` ✅ (全24スクリーンショットで正常レンダリング確認)