### PR TITLE
feat: Add light transparency to tank blocks

### DIFF
--- a/src/main/kotlin/net/turtton/connectedtank/block/CTBlocks.kt
+++ b/src/main/kotlin/net/turtton/connectedtank/block/CTBlocks.kt
@@ -38,7 +38,14 @@ object CTBlocks {
 
     private fun register(tier: TankTier): Block {
         val blockKey = RegistryKey.of(RegistryKeys.BLOCK, ModIdentifier(tier.id))
-        val settings = AbstractBlock.Settings.create().nonOpaque().strength(tier.hardness).registryKey(blockKey)
+        val settings = AbstractBlock.Settings.create()
+            .nonOpaque()
+            .strength(tier.hardness)
+            .allowsSpawning { _, _, _, _ -> false }
+            .solidBlock { _, _, _ -> false }
+            .suffocates { _, _, _ -> false }
+            .blockVision { _, _, _ -> false }
+            .registryKey(blockKey)
         val block = ConnectedTankBlock(tier, settings)
         return Registry.register(Registries.BLOCK, blockKey, block)
     }

--- a/src/main/kotlin/net/turtton/connectedtank/block/ConnectedTankBlock.kt
+++ b/src/main/kotlin/net/turtton/connectedtank/block/ConnectedTankBlock.kt
@@ -25,6 +25,7 @@ import net.minecraft.util.hit.BlockHitResult
 import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.Direction
 import net.minecraft.util.math.random.Random
+import net.minecraft.world.BlockView
 import net.minecraft.world.World
 import net.minecraft.world.WorldView
 import net.minecraft.world.tick.ScheduledTickView
@@ -98,6 +99,10 @@ class ConnectedTankBlock(val tier: TankTier, settings: Settings) :
         val property = DIRECTION_PROPERTIES[direction] ?: return super.isSideInvisible(state, stateFrom, direction)
         return state.get(property) || super.isSideInvisible(state, stateFrom, direction)
     }
+
+    override fun isTransparent(state: BlockState): Boolean = true
+
+    override fun getAmbientOcclusionLightLevel(state: BlockState, world: BlockView, pos: BlockPos): Float = 1.0F
 
     override fun onStateReplaced(state: BlockState, world: ServerWorld, pos: BlockPos, moved: Boolean) {
         val persistentState = world.persistentStateManager.getOrCreate(FluidStoragePersistentState.TYPE)


### PR DESCRIPTION
## Summary
- タンクブロックに光透過性を追加（`isTransparent()` override で opacity = 0）
- AO 暗化を除去（`getAmbientOcclusionLightLevel()` = 1.0F）
- ガラス相当の block settings 追加（`allowsSpawning` / `solidBlock` / `suffocates` / `blockVision` を false に設定）

## Changes
- `ConnectedTankBlock.kt`: `isTransparent()` + `getAmbientOcclusionLightLevel()` override 追加
- `CTBlocks.kt`: block settings にガラス相当の predicate 追加